### PR TITLE
Separate napari tests into its own category

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,19 @@ jobs:
         - make install-dev slow-test
       after_success:
         - bash <(curl -s https://codecov.io/bash)
-    - name: Install Napari
+    - name: Install Napari & Test napari
       if: type = push and (branch = master or branch =~ /-alltest/)
-      script: pip install .[napari]
+      dist: xenial
+      before_install:
+        - sudo apt-get install -y libgl1-mesa-glx libqt5x11extras5 xvfb
+        - make install-dev
+        - pip install .[napari]
+        - export DISPLAY=:99
+        - Xvfb $DISPLAY -ac -screen 0 1024x768x24 &
+        - sleep 10
+      script:
+        - python -c "import vispy; print(vispy.sys_info())"
+        - make napari-test
     - name: Docker
       if: type = push and (branch = master or branch =~ /-alltest/)
       script: make docker
@@ -88,7 +98,7 @@ jobs:
       script: make TESTING=1 install-dev iss_pipeline.py
     - name: Released Notebooks
       if: type = cron and (branch = master or branch =~ /-alltest/)
-      script: make check-notebooks install-released-notebooks-support run-notebooks
+            script: make check-notebooks install-released-notebooks-support run-notebooks
 cache:
   directories:
   - $HOME/.cache/pip

--- a/Makefile
+++ b/Makefile
@@ -39,14 +39,20 @@ lint-non-init:
 lint-init:
 	flake8 --ignore 'E252, E301, E302, E305, E401, F401, W503, E731, F811' --filename='*__init__.py' $(MODULES)
 
+# note that napari tests shouldn't be run in parallel because Qt seems to intermittently fail when multiple QApplications are spawned on threads.
 test:
-	pytest -v -n 8 --cov starfish
+	pytest -v -n 8 --cov starfish -m 'not napari'
+	pytest -v --cov starfish -m 'napari'
 
 fast-test:
-	pytest -v -n 8 --cov starfish -m 'not slow'
+	pytest -v -n 8 --cov starfish -m 'not (slow or napari)'
 
 slow-test:
-	pytest -v -n 8 --cov starfish -m 'slow'
+	pytest -v -n 8 --cov starfish -m 'slow and (not napari)'
+
+# note that this shouldn't be run in parallel because Qt seems to intermittently fail when multiple QApplications are spawned on threads.
+napari-test:
+	pytest -v --cov starfish -m 'napari'
 
 mypy:
 	mypy --ignore-missing-imports $(MODULES)

--- a/REQUIREMENTS-CI.txt
+++ b/REQUIREMENTS-CI.txt
@@ -5,7 +5,7 @@ mypy
 numpydoc
 nbencdec >= 0.0.5
 pycodestyle==2.5.0
-pytest>=3.6.3
+pytest>=4.4.0
 pytest-cov>=2.5.1
 pytest-xdist
 recommonmark

--- a/starfish/core/test/test_display.py
+++ b/starfish/core/test/test_display.py
@@ -1,8 +1,5 @@
-import napari
 import numpy as np
 import pytest
-from qtpy.QtCore import QTimer
-from qtpy.QtWidgets import QApplication
 
 from starfish import display, SegmentationMaskCollection
 from starfish.core.test.factories import SyntheticData
@@ -30,10 +27,15 @@ masks = SegmentationMaskCollection.from_label_image(
 )
 
 
+@pytest.mark.napari
 @pytest.mark.parametrize('masks', [masks, None], ids=['masks', '     '])
 @pytest.mark.parametrize('spots', [spots, None], ids=['spots', '     '])
 @pytest.mark.parametrize('stack', [stack, None], ids=['stack', '     '])
 def test_display(stack, spots, masks):
+    import napari
+    from qtpy.QtCore import QTimer
+    from qtpy.QtWidgets import QApplication
+
     def run():
         app = QApplication.instance() or QApplication([])
         viewer = napari.Viewer()


### PR DESCRIPTION
1. Run them as part of the napari install test that's run on master branches.  This test now sets up a headless environment for napari display tests.
2. Move the napari and pyqt imports inside test_display() so they don't trip up tests when napari isn't installed.
3. Upgrade pytest version.

Test plan: named this branch -alltest, so it should hit all the test cases.